### PR TITLE
[Removed] Sticker purge on insert in flavor of MongoDB capped collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
@@ -42,6 +43,17 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/StickerDatabase.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/StickerDatabase.java
@@ -1,14 +1,10 @@
 package com.cookiebot.cookiebotbackend.core.domains;
 
-import java.io.Serializable;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "stickerdatabase")
-public class StickerDatabase implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
+public class StickerDatabase {
 	@Id
 	private String id;
 	

--- a/src/main/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseService.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseService.java
@@ -1,23 +1,22 @@
 package com.cookiebot.cookiebotbackend.dao.services;
 
+import com.cookiebot.cookiebotbackend.dao.services.exceptions.ObjectNotFoundException;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.stereotype.Service;
 
 import com.cookiebot.cookiebotbackend.core.domains.StickerDatabase;
 import com.cookiebot.cookiebotbackend.dao.repository.StickerDatabaseRepository;
 import com.cookiebot.cookiebotbackend.dao.services.exceptions.BadRequestException;
 
+import java.util.List;
+
 @Service
 public class StickerDatabaseService {
 
 	private final StickerDatabaseRepository repository;
-	private final MongoOperations mongoOperations;
 
-	public StickerDatabaseService(StickerDatabaseRepository repository, MongoOperations mongoOperations) {
+	public StickerDatabaseService(final StickerDatabaseRepository repository) {
 		this.repository = repository;
-        this.mongoOperations = mongoOperations;
     }
 
 	public StickerDatabase getRandom(){

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
@@ -37,7 +37,7 @@ public class StickerDatabaseServiceTest {
 
     @Test
     void insertTest() {
-        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
+        StickerDatabaseService service = new StickerDatabaseService(repository);
 
         StickerDatabase stickerDatabase = new StickerDatabase();
         stickerDatabase.setId("123");
@@ -49,7 +49,7 @@ public class StickerDatabaseServiceTest {
 
     @Test
     void insertWithExistingId() {
-        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
+        StickerDatabaseService service = new StickerDatabaseService(repository);
 
         StickerDatabase stickerDatabase = new StickerDatabase();
         stickerDatabase.setId("123");

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
@@ -3,6 +3,7 @@ package com.cookiebot.cookiebotbackend.dao.services;
 import com.cookiebot.cookiebotbackend.core.domains.StickerDatabase;
 import com.cookiebot.cookiebotbackend.dao.repository.StickerDatabaseRepository;
 import com.cookiebot.cookiebotbackend.dao.services.exceptions.BadRequestException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -57,5 +58,10 @@ public class StickerDatabaseServiceTest {
         service.insert(stickerDatabase);
 
         assertThrows(BadRequestException.class, () -> service.insert(stickerDatabase));
+    }
+
+    @AfterEach
+    public void cleanup() {
+        this.mongoOperations.dropCollection(StickerDatabase.class);
     }
 }

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
@@ -1,0 +1,61 @@
+package com.cookiebot.cookiebotbackend.dao.services;
+
+import com.cookiebot.cookiebotbackend.core.domains.StickerDatabase;
+import com.cookiebot.cookiebotbackend.dao.repository.StickerDatabaseRepository;
+import com.cookiebot.cookiebotbackend.dao.services.exceptions.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataMongoTest
+@Testcontainers
+public class StickerDatabaseServiceTest {
+
+    @Container
+    public static MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.4.3"));
+
+    @Autowired
+    private StickerDatabaseRepository repository;
+
+    @Autowired
+    private MongoOperations mongoOperations;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+    }
+
+    @Test
+    void insertTest() {
+        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
+
+        StickerDatabase stickerDatabase = new StickerDatabase();
+        stickerDatabase.setId("123");
+
+        StickerDatabase saved = service.insert(stickerDatabase);
+
+        assertEquals(stickerDatabase.getId(), saved.getId());
+    }
+
+    @Test
+    void insertWithExistingId() {
+        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
+
+        StickerDatabase stickerDatabase = new StickerDatabase();
+        stickerDatabase.setId("123");
+
+        service.insert(stickerDatabase);
+
+        assertThrows(BadRequestException.class, () -> service.insert(stickerDatabase));
+    }
+}


### PR DESCRIPTION
Hello, I hope you are good.

Removed the logic to remove a sticker when insert when the collection size is exceeded a threshold to use MongoDB capped collection functionality. This approach will be more optimal and efficient.

> Capped collections are fixed-size collections that insert and retrieve documents based on insertion order. Capped collections work similarly to circular buffers: once a collection fills its allocated space, it makes room for new documents by overwriting the oldest documents in the collection.
https://www.mongodb.com/docs/manual/core/capped-collections/

It's possible to convert a collection to capped one:
```
db.runCommand( {
   convertToCapped: "log2",
   size: 100000
} )
```
https://www.mongodb.com/docs/manual/core/capped-collections/convert-collection-to-capped/#std-label-capped-collections-convert

The size of a capped collection can be altered after its creation.

Have a wonderful day