### PR TITLE
[Improved] Random selection of stickers

### DIFF
--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/StickerDatabase.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/StickerDatabase.java
@@ -3,6 +3,8 @@ package com.cookiebot.cookiebotbackend.core.domains;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Objects;
+
 @Document(collection = "stickerdatabase")
 public class StickerDatabase {
 	@Id
@@ -22,5 +24,18 @@ public class StickerDatabase {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		StickerDatabase that = (StickerDatabase) o;
+		return Objects.equals(id, that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(id);
 	}
 }

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/DataGenerator.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/DataGenerator.java
@@ -1,0 +1,15 @@
+package com.cookiebot.cookiebotbackend.dao;
+
+import com.cookiebot.cookiebotbackend.core.domains.StickerDatabase;
+
+import java.util.UUID;
+
+public final class DataGenerator {
+
+    public static StickerDatabase generateSticker() {
+        final var sticker = new StickerDatabase();
+        sticker.setId(UUID.randomUUID().toString());
+
+        return sticker;
+    }
+}

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/StickerDatabaseServiceTest.java
@@ -1,6 +1,7 @@
 package com.cookiebot.cookiebotbackend.dao.services;
 
 import com.cookiebot.cookiebotbackend.core.domains.StickerDatabase;
+import com.cookiebot.cookiebotbackend.dao.DataGenerator;
 import com.cookiebot.cookiebotbackend.dao.repository.StickerDatabaseRepository;
 import com.cookiebot.cookiebotbackend.dao.services.exceptions.BadRequestException;
 import org.junit.jupiter.api.AfterEach;
@@ -15,8 +16,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.stream.IntStream;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataMongoTest
 @Testcontainers
@@ -38,7 +45,7 @@ public class StickerDatabaseServiceTest {
 
     @Test
     void insertTest() {
-        StickerDatabaseService service = new StickerDatabaseService(repository);
+        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
 
         StickerDatabase stickerDatabase = new StickerDatabase();
         stickerDatabase.setId("123");
@@ -50,7 +57,7 @@ public class StickerDatabaseServiceTest {
 
     @Test
     void insertWithExistingId() {
-        StickerDatabaseService service = new StickerDatabaseService(repository);
+        StickerDatabaseService service = new StickerDatabaseService(repository, mongoOperations);
 
         StickerDatabase stickerDatabase = new StickerDatabase();
         stickerDatabase.setId("123");
@@ -58,6 +65,77 @@ public class StickerDatabaseServiceTest {
         service.insert(stickerDatabase);
 
         assertThrows(BadRequestException.class, () -> service.insert(stickerDatabase));
+    }
+
+    @Test
+    void randomStickerOneSticker() {
+        final var service = new StickerDatabaseService(repository, mongoOperations);
+        final var sticker = DataGenerator.generateSticker();
+        service.insert(sticker);
+
+        final var actual = service.getRandom();
+
+        assertEquals(sticker.getId(), actual.getId());
+    }
+
+    /**
+     * This test case validates the logic of the {@link StickerDatabaseService#getRandom()} method.
+     * The test generates and inserts 50 random StickerDatabase objects into the repository.
+     * It then performs 50 testing iterations and each iteration continues to fetch
+     * random StickerDatabase objects from the repository until a duplicate (previously fetched)
+     * StickerDatabase object is encountered.
+     * <p>
+     * The retrieval logic in each iteration represents a scenario of repetitive database
+     * access with the intention of getting unique StickerDatabase items each time.
+     * The HashSet data structure is used to ensure the uniqueness of fetched items in each iteration.
+     * <p>
+     * After the iterations, the test calculates an average of the unique
+     * StickerDatabase objects fetched in each iteration.
+     * The test asserts that this average number must be greater than 3.
+     * <p>
+     * Thus, the test verifies that {@link StickerDatabaseService#getRandom()} can produce a
+     * reasonable ratio of unique StickerDatabase objects under the given testing scenario.
+     */
+    @Test
+    void randomStickerMultipleStickers() {
+        final var service = new StickerDatabaseService(repository, mongoOperations);
+        final var stickers = IntStream.range(0, 50)
+                .mapToObj(__ -> DataGenerator.generateSticker())
+                .toList();
+
+        stickers.forEach(service::insert);
+
+        final var testIterations = 50;
+        final var testResult = new ArrayList<HashSet<StickerDatabase>>(testIterations);
+
+        for (int i = 0; i < testIterations; i++) {
+            final var previousStickers = new HashSet<StickerDatabase>();
+
+            for (;;) {
+                final var actual = service.getRandom();
+
+                if (previousStickers.contains(actual)) {
+                    break;
+                }
+
+                previousStickers.add(actual);
+            }
+
+            testResult.add(previousStickers);
+        }
+
+        final var averageDifferentStickers = testResult.stream().mapToInt(HashSet::size).average().orElseThrow();
+
+        assertTrue(averageDifferentStickers > 3);
+    }
+
+    @Test
+    void randomStickerEmpty() {
+        final var service = new StickerDatabaseService(repository, mongoOperations);
+
+        final var actual = service.getRandom();
+
+        assertNull(actual);
     }
 
     @AfterEach


### PR DESCRIPTION
Hello, I hope you are good.

Changed the random selection stickers to use MongoDB aggregate sample operator to fetch a single random sticker from the collection. This reduces the used memory as well as the processing time to return a random sticker.

> **$sample** 
> 
> Randomly selects the specified number of documents from the input documents.
> The [$sample](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#mongodb-pipeline-pipe.-sample) stage has the following syntax:
> { $sample: { size: \<positive integer N\> } }
> 
> N is the number of documents to randomly select.
>
> https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/

Have a wonderful day ^^