### PR TITLE
[Improved] Raffle participant feature performance

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,16 @@
+name: Compile and test
+run-name: Compile and test ${{ github.actor }}
+on: [push]
+jobs:
+  compile-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify

--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/Raffle.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/Raffle.java
@@ -2,6 +2,7 @@ package com.cookiebot.cookiebotbackend.core.domains;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -56,5 +57,23 @@ public class Raffle {
 
 	public void setParticipants(List<RaffleParticipant> participants) {
 		this.participants = participants;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Raffle raffle = (Raffle) o;
+
+		return Objects.equals(name, raffle.name) &&
+				Objects.equals(award, raffle.award) &&
+				Objects.equals(deadline, raffle.deadline) &&
+				Objects.equals(participants, raffle.participants);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, award, deadline, participants);
 	}
 }

--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/Raffle.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/Raffle.java
@@ -1,6 +1,5 @@
 package com.cookiebot.cookiebotbackend.core.domains;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,8 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "raffles")
-public class Raffle implements Serializable {
-	private static final long serialVersionUID = 1L;
+public class Raffle {
 	
 	@Id
 	private String name;

--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/RaffleParticipant.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/RaffleParticipant.java
@@ -1,10 +1,8 @@
 package com.cookiebot.cookiebotbackend.core.domains;
 
-import java.io.Serializable;
+import java.util.Objects;
 
-public class RaffleParticipant implements Serializable {
-	private static final long serialVersionUID = 1L;
-	
+public class RaffleParticipant {
 	private String user;
 	
 	public RaffleParticipant() {
@@ -21,5 +19,18 @@ public class RaffleParticipant implements Serializable {
 
 	public void setUser(String user) {
 		this.user = user;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RaffleParticipant that = (RaffleParticipant) o;
+		return Objects.equals(user, that.user);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(user);
 	}
 }

--- a/src/main/java/com/cookiebot/cookiebotbackend/core/domains/RaffleParticipant.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/core/domains/RaffleParticipant.java
@@ -3,6 +3,8 @@ package com.cookiebot.cookiebotbackend.core.domains;
 import java.util.Objects;
 
 public class RaffleParticipant {
+	public static final String USER_FIELD = "user";
+
 	private String user;
 	
 	public RaffleParticipant() {

--- a/src/main/java/com/cookiebot/cookiebotbackend/endpoint/resources/RaffleResource.java
+++ b/src/main/java/com/cookiebot/cookiebotbackend/endpoint/resources/RaffleResource.java
@@ -41,9 +41,13 @@ public class RaffleResource {
 	
 	@PostMapping(value = "/{name}")
 	public ResponseEntity<Raffle> insert(@RequestBody Raffle raffle, @PathVariable String name) {
-		service.insert(name, raffle);
+		raffle.setName(name);
+
+		service.insert(raffle);
+
 		URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
 				.path("/{name}").buildAndExpand(name).toUri();
+
 		return ResponseEntity.created(uri).build();
 	}
 	

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/RaffleServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/RaffleServiceTest.java
@@ -1,0 +1,112 @@
+package com.cookiebot.cookiebotbackend.dao.services;
+
+import com.cookiebot.cookiebotbackend.core.domains.Raffle;
+import com.cookiebot.cookiebotbackend.core.domains.RaffleParticipant;
+import com.cookiebot.cookiebotbackend.dao.repository.RaffleRepository;
+import com.cookiebot.cookiebotbackend.dao.services.exceptions.BadRequestException;
+import com.cookiebot.cookiebotbackend.dao.services.exceptions.ObjectNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataMongoTest
+@Testcontainers
+class RaffleServiceTest {
+
+    @Container
+    public static MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.4.3"));
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private RaffleRepository repository;
+
+    private RaffleService raffleService;
+
+    @BeforeEach
+    public void setup() {
+        this.raffleService = new RaffleService(repository, mongoTemplate);
+    }
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+    }
+
+    @Test
+    void testInsertParticipant() {
+        Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        RaffleParticipant participant = new RaffleParticipant();
+        participant.setUser("a");
+
+        raffleService.insert(raffle);
+        raffleService.insertParticipant(raffle.getName(), participant);
+
+        Raffle updatedRaffle = repository.findById("123").get();
+
+        assertEquals(1, updatedRaffle.getParticipants().size());
+        assertEquals(participant, updatedRaffle.getParticipants().get(0));
+    }
+
+    @Test
+    void testInsertParticipantNoUserShouldThrowException() {
+        Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        RaffleParticipant participant = new RaffleParticipant();
+        participant.setUser(null);
+
+        assertThrows(BadRequestException.class, () -> raffleService.insertParticipant(raffle.getName(), participant));
+    }
+
+    @Test
+    void testInsertParticipantRaffleDoesNotExistShouldThrowException() {
+        RaffleParticipant participant = new RaffleParticipant();
+        participant.setUser("user1");
+
+        assertThrows(ObjectNotFoundException.class, () -> raffleService.insertParticipant("nonexistentId", participant));
+    }
+
+    @Test
+    void testInsertParticipantAlreadyInRaffleShouldNotAddParticipant() {
+        Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        raffleService.insert(raffle);
+
+        RaffleParticipant participant = new RaffleParticipant();
+        participant.setUser("user1");
+
+        // Add the participant once
+        raffleService.insertParticipant(raffle.getName(), participant);
+
+        // Attempt to add the participant a second time
+        raffleService.insertParticipant(raffle.getName(), participant);
+
+        Raffle updatedRaffle = repository.findById(raffle.getName()).get();
+
+        // Despite two attempts to add, there should only be one participant in the raffle
+        assertEquals(1, updatedRaffle.getParticipants().size());
+        assertEquals(participant, updatedRaffle.getParticipants().get(0));
+    }
+
+    @AfterEach
+    public void cleanup() {
+        this.mongoTemplate.dropCollection(Raffle.class);
+    }
+
+}

--- a/src/test/java/com/cookiebot/cookiebotbackend/dao/services/RaffleServiceTest.java
+++ b/src/test/java/com/cookiebot/cookiebotbackend/dao/services/RaffleServiceTest.java
@@ -18,6 +18,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataMongoTest
@@ -102,6 +104,71 @@ class RaffleServiceTest {
         // Despite two attempts to add, there should only be one participant in the raffle
         assertEquals(1, updatedRaffle.getParticipants().size());
         assertEquals(participant, updatedRaffle.getParticipants().get(0));
+    }
+
+    @Test
+    void testDeleteParticipant() {
+        final Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        final RaffleParticipant participantBob = new RaffleParticipant();
+        participantBob.setUser("bob");
+
+        final RaffleParticipant participantAna = new RaffleParticipant();
+        participantAna.setUser("ana");
+
+        raffleService.insert(raffle);
+        raffleService.insertParticipant(raffle.getName(), participantBob);
+        raffleService.insertParticipant(raffle.getName(), participantAna);
+
+        raffleService.deleteParticipant(raffle.getName(), participantBob);
+
+        final Raffle updatedRaffle = repository.findById(raffle.getName()).orElseThrow();
+
+        assertEquals(1, updatedRaffle.getParticipants().size());
+        assertEquals(participantAna, updatedRaffle.getParticipants().get(0));
+    }
+
+    @Test
+    void testDeleteParticipantNonExistent() {
+        final Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        final RaffleParticipant participantNotInRaffle = new RaffleParticipant();
+        participantNotInRaffle.setUser("bob");
+
+        final RaffleParticipant participantAna = new RaffleParticipant();
+        participantAna.setUser("ana");
+
+        raffle.setParticipants(List.of(participantAna));
+
+        raffleService.insert(raffle);
+        raffleService.insertParticipant(raffle.getName(), participantAna);
+
+        raffleService.deleteParticipant(raffle.getName(), participantNotInRaffle);
+
+        final Raffle updatedRaffle = repository.findById(raffle.getName()).orElseThrow();
+
+        assertEquals(1, updatedRaffle.getParticipants().size());
+        assertEquals(participantAna, updatedRaffle.getParticipants().get(0));
+
+        assertEquals(raffle, updatedRaffle);
+    }
+
+    @Test
+    void testDeleteParticipantNoParticipants() {
+        final Raffle raffle = new Raffle();
+        raffle.setName("123");
+
+        final RaffleParticipant participantNotInRaffle = new RaffleParticipant();
+        participantNotInRaffle.setUser("bob");
+
+        raffleService.insert(raffle);
+        raffleService.deleteParticipant(raffle.getName(), participantNotInRaffle);
+
+        final Raffle updatedRaffle = repository.findById(raffle.getName()).orElseThrow();
+
+        assertEquals(0, updatedRaffle.getParticipants().size());
     }
 
     @AfterEach


### PR DESCRIPTION
Hello, I hope you are good.

Changed Raffle Service with performance improvemens:
-  Including a participant in a raffle to use MongoDB $addToSet operator to not load the raffle in memory.
- Remove a participant from a raffle to use MongoDB $pull operator to not load the raffle in memory

Added a GitHub workflow to compile and run tests automatically.

Have a wonderful day.